### PR TITLE
pm no more closes the original shell on Ctrl+C

### DIFF
--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"os/user"
+	"syscall"
 
 	"github.com/pkg/errors"
 )
@@ -20,8 +22,11 @@ func Shell(cwd string) {
 	//technosophos.com/2014/07/11/start-an-interactive-shell-from-within-go.html
 	defer handleShellError()
 
+	// silent the ctrl+c / SIGTERM signals
+	SilentCtrlC()
+
 	fmt.Println("Starting new shell")
-	fmt.Println("Use 'CTRL + C' or '$ exit' to terminate child shell")
+	fmt.Println("Use 'exit' to terminate child shell")
 
 	// Get the current user.
 	me, err := user.Current()
@@ -57,4 +62,12 @@ func Shell(cwd string) {
 	// os.Setenv("PROMPT", "()")
 	// Keep on keepin' on.
 	fmt.Printf("Exited Go Sub Shell\n %s\n", state.String())
+}
+
+func SilentCtrlC() {
+	// listen to terminate signales
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// and don't so anything
+	go func() { <-c }()
 }


### PR DESCRIPTION
When hitting CTRL+C inside a `pm` subshell, the shell is closed alongside original shell parenting  the `pm` process

![Screen Shot 2020-05-22 at 15 34 20](https://user-images.githubusercontent.com/8197916/82713998-b7e0ed00-9c41-11ea-8f92-fee597d6edb8.png)

The new code silents the ctrl+c, and mirrors the shell behaviour, as they don't respond to ctrl+c either